### PR TITLE
Fix minor version and cleanup action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,39 +1,35 @@
-name: Release
+name: CI/CD
 
+on: [push, pull_request]
 on:
   push:
     tags:
       - v*
+    branches:
+      - 'fix/release-versions'
+  pull_request:
+    branches:
+      - 'main'
+
 
 jobs:
   macos:
     runs-on: macos-latest
+    strategy:
+      matrix:
+        target: [x64, x86, aarch64]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-          architecture: x64
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          default: true
-      - name: Build wheels - x86_64
+      - name: Build wheels
         uses: messense/maturin-action@v1
         with:
-          target: x86_64
-          args: --release --out dist
-      - name: Install built wheel - x86_64
-        run: |
-          pip install didkit --no-index --find-links dist --force-reinstall
-          python -c "import didkit"
-      - name: Build wheels - universal2
-        uses: messense/maturin-action@v1
-        with:
-          args: --release --universal2 --out dist --no-sdist
-      - name: Install built wheel - universal2
+          target: ${{ matrix.target }}
+          args: --release --out dist --no-sdist
+      # - uses: actions/setup-python@v2
+      #   with:
+      #     python-version: 3.9
+      #     architecture: x64
+      - name: Install built wheel
         run: |
           pip install didkit --no-index --find-links dist --force-reinstall
           python -c "import didkit"
@@ -47,25 +43,20 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        target: [x64, x86]
+        target: [x64, x86, aarch64]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-          architecture: ${{ matrix.target }}
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          default: true
       - name: Build wheels
         uses: messense/maturin-action@v1
         with:
           target: ${{ matrix.target }}
           args: --release --out dist --no-sdist
+      # - uses: actions/setup-python@v2
+      #   with:
+      #     python-version: 3.9
+      #     architecture: ${{ matrix.target }}
       - name: Install built wheel
+        # if: matrix.target == 'x64'
         run: |
           pip install didkit --no-index --find-links dist --force-reinstall
           python -c "import didkit"
@@ -79,19 +70,19 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [x86_64, i686]
+        target: [x86_64, i686, aarch64, armv7, s390x, ppc64le, ppc64]
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-      with:
-        python-version: 3.9
-        architecture: x64
     - name: Build Wheels
       uses: messense/maturin-action@v1
       with:
         target: ${{ matrix.target }}
         manylinux: auto
-        args: --release --out dist --no-sdist
+        args: --release --out dist
+    # - uses: actions/setup-python@v2
+    #   with:
+    #     python-version: 3.9
+    #     architecture: x64
     - name: Install built wheel
       if: matrix.target == 'x86_64'
       run: |
@@ -103,59 +94,13 @@ jobs:
         name: wheels
         path: dist
 
-  linux-cross:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        target: [aarch64, armv7, s390x, ppc64le, ppc64]
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-      with:
-        python-version: 3.9
-    - name: Build Wheels
-      uses: messense/maturin-action@v1
-      env:
-        PYO3_CROSS_LIB_DIR: /opt/python/cp39-cp39/lib
-      with:
-        target: ${{ matrix.target }}
-        manylinux: auto
-        args: --release --out dist --no-sdist
-    # TODO Cannot find wheels, probably due to wrong Python version?
-    # - uses: uraimo/run-on-arch-action@v2.0.5
-    #   if: matrix.target != 'ppc64'
-    #   name: Install built wheel
-    #   with:
-    #     arch: ${{ matrix.target }}
-    #     distro: ubuntu18.04
-    #     githubToken: ${{ github.token }}
-    #     # Mount the dist directory as /artifacts in the container
-    #     dockerRunArgs: |
-    #       --volume "${PWD}/dist:/artifacts"
-    #     install: |
-    #       apt-get update
-    #       apt-get install -y --no-install-recommends python3 python3-pip
-    #       pip3 install -U pip
-    #     run: |
-    #       ls -lrth /artifacts
-    #       pip3 install didkit --no-index --find-links /artifacts --force-reinstall
-    #       python3 -c "import didkit"
-    - name: Upload wheels
-      uses: actions/upload-artifact@v2
-      with:
-        name: wheels
-        path: dist
-
   # TODO Add pypy
 
   release:
-    strategy:
-      matrix:
-        python: [3.7, 3.8, 3.9, 3.10]
     name: Release
     runs-on: ubuntu-latest
     if: "startsWith(github.ref, 'refs/tags/')"
-    needs: [ macos, linux, linux-cross, windows]
+    needs: [ macos, linux, windows]
     steps:
       - uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - v*
-    branches:
-      - 'fix/release-versions'
   pull_request:
     branches:
       - 'main'
@@ -24,10 +22,6 @@ jobs:
         with:
           target: ${{ matrix.target }}
           args: --release --out dist --no-sdist
-      # - uses: actions/setup-python@v2
-      #   with:
-      #     python-version: 3.9
-      #     architecture: x64
       - name: Install built wheel
         if: matrix.target == 'x64'
         run: |
@@ -51,10 +45,6 @@ jobs:
         with:
           target: ${{ matrix.target }}
           args: --release --out dist --no-sdist
-      # - uses: actions/setup-python@v2
-      #   with:
-      #     python-version: 3.9
-      #     architecture: ${{ matrix.target }}
       - name: Install built wheel
         if: matrix.target == 'x64'
         run: |
@@ -81,10 +71,6 @@ jobs:
         target: ${{ matrix.target }}
         manylinux: auto
         args: --release --out dist
-    # - uses: actions/setup-python@v2
-    #   with:
-    #     python-version: 3.9
-    #     architecture: x64
     - name: Install built wheel
       if: matrix.target == 'x86_64'
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build Wheels
       uses: messense/maturin-action@v1
+      env:
+        PYO3_CROSS_LIB_DIR: /opt/python/cp37-cp37/lib
       with:
         target: ${{ matrix.target }}
         manylinux: auto

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,5 @@
 name: CI/CD
 
-on: [push, pull_request]
 on:
   push:
     tags:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - v*
-    branches:
-      - feat/pyo3
 
 jobs:
   macos:
@@ -151,17 +149,20 @@ jobs:
   # TODO Add pypy
 
   release:
+    strategy:
+      matrix:
+        python: [3.7, 3.8, 3.9, 3.10]
     name: Release
     runs-on: ubuntu-latest
     if: "startsWith(github.ref, 'refs/tags/')"
-    needs: [ macos, linux, linux-cross ] # windows,
+    needs: [ macos, linux, linux-cross, windows]
     steps:
       - uses: actions/download-artifact@v2
         with:
           name: wheels
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: ${{ matrix.python }}
       - name: Publish to PyPi
         env:
           TWINE_USERNAME: __token__

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
           name: wheels
       - uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python }}
+          python-version: 3.9
       - name: Publish to PyPi
         env:
           TWINE_USERNAME: __token__

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        target: [x64, x86, aarch64]
+        target: [x64, aarch64]
     steps:
       - uses: actions/checkout@v2
       - name: Build wheels

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
       #     python-version: 3.9
       #     architecture: x64
       - name: Install built wheel
+        if: matrix.target == 'x64'
         run: |
           pip install didkit --no-index --find-links dist --force-reinstall
           python -c "import didkit"
@@ -55,7 +56,7 @@ jobs:
       #     python-version: 3.9
       #     architecture: ${{ matrix.target }}
       - name: Install built wheel
-        # if: matrix.target == 'x64'
+        if: matrix.target == 'x64'
         run: |
           pip install didkit --no-index --find-links dist --force-reinstall
           python -c "import didkit"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [x86_64, i686, aarch64, armv7, s390x]
+        target: [x86_64, i686, aarch64, armv7]
     steps:
     - uses: actions/checkout@v2
     - name: Build Wheels

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        target: [x64, x86, aarch64]
+        target: [x64, x86]
     steps:
       - uses: actions/checkout@v2
       - name: Build wheels

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,7 @@ jobs:
       env:
         PYO3_CROSS_LIB_DIR: /opt/python/cp37-cp37/lib
       with:
+        maturin-version: v0.12.11
         target: ${{ matrix.target }}
         manylinux: auto
         args: --release --out dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,9 +75,8 @@ jobs:
     - name: Build Wheels
       uses: messense/maturin-action@v1
       env:
-        PYO3_CROSS_LIB_DIR: /opt/python/cp37-cp37/lib
+        PYO3_CROSS_LIB_DIR: /opt/python/cp38-cp38/lib
       with:
-        # maturin-version: v0.12.11
         target: ${{ matrix.target }}
         manylinux: auto
         args: --release --out dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [x86_64, i686, aarch64, armv7]
+        target: [x86_64, i686, aarch64, armv7, s390x, ppc64le, ppc64]
     steps:
     - uses: actions/checkout@v2
     - name: Build Wheels

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [x86_64, i686, aarch64, armv7, s390x, ppc64le, ppc64]
+        target: [x86_64, i686, aarch64, armv7, s390x]
     steps:
     - uses: actions/checkout@v2
     - name: Build Wheels
@@ -77,7 +77,7 @@ jobs:
       env:
         PYO3_CROSS_LIB_DIR: /opt/python/cp37-cp37/lib
       with:
-        maturin-version: v0.12.11
+        # maturin-version: v0.12.11
         target: ${{ matrix.target }}
         manylinux: auto
         args: --release --out dist


### PR DESCRIPTION
Certain odd linux architectures are stuck on 3.8 (e.g. arm, or powerpc) but now all OS with their major archs have 3.7--3.10 available.

Wheels artifacts available under e.g. https://github.com/spruceid/didkit-python/actions/runs/1989782516

Close #2 
Close #3 